### PR TITLE
Use errno.ENOENT instead of hard coded value

### DIFF
--- a/pickleshare.py
+++ b/pickleshare.py
@@ -47,6 +47,7 @@ try:
 except ImportError:
     import pickle
 import glob
+import errno
 
 def gethashfile(key):
     return ("%02x" % abs(hash(key) % 256))[-2:]
@@ -97,7 +98,7 @@ class PickleShareDB(collections.MutableMapping):
         try:
             self.cache[fil] = (value,fil.mtime)
         except OSError as e:
-            if e.errno != 2:
+            if e.errno != errno.ENOENT:
                 raise
 
     def hset(self, hashroot, key, value):


### PR DESCRIPTION
This was reported by lintian4py here: https://code.google.com/p/spyderlib/issues/detail?id=1715