### PR TITLE
fix already exists error if same code happens many times simultaneously

### DIFF
--- a/pickleshare.py
+++ b/pickleshare.py
@@ -60,7 +60,7 @@ class PickleShareDB(collections.MutableMapping):
         """ Return a db object that will manage the specied directory"""
         self.root = Path(root).expanduser().abspath()
         if not self.root.isdir():
-            self.root.makedirs()
+            self.root.makedirs_p()
         # cache has { 'key' : (obj, orig_mod_time) }
         self.cache = {}
 


### PR DESCRIPTION
This is #3 rebased with path.py removed.

makedirs_p was added to path.py in 2010, so it's safe to rely on it.