### PR TITLE
don't use deprecated path.py import

### DIFF
--- a/pickleshare.py
+++ b/pickleshare.py
@@ -38,7 +38,7 @@ from __future__ import print_function
 
 __version__ = "0.5"
 
-from path import path as Path
+from path import Path
 # from IPython.external.path import path as Path
 import os,stat,time
 import collections

--- a/pickleshare.py
+++ b/pickleshare.py
@@ -36,7 +36,7 @@ License: MIT open source license.
 from __future__ import print_function
 
 
-__version__ = "0.5"
+__version__ = "0.6"
 
 from path import Path
 # from IPython.external.path import path as Path


### PR DESCRIPTION
After [commit #62ccb762](https://github.com/jaraco/path.py/commit/62ccb7623d4d048af663f205e21c2ec3f24fa17d) in `path.py`, the `path` alias is no longer available. Clients must now refer to the canonical name `Path` as introduced in 6.2.

This results in, for example, iPython not being able to run after doing a clean install with `pip`. That is why a version bump is also needed, to prevent this problem:

    $ mkvirtualenv test
    $ pip install ipython
    $ ipython
    Traceback (most recent call last):
      File "/home/peque/.virtualenvs/test/bin/ipython", line 7, in <module>
        from IPython import start_ipython
      File "/home/peque/.virtualenvs/test/lib/python2.7/site-packages/IPython/__init__.py", line 48, in <module>
        from .terminal.embed import embed
      File "/home/peque/.virtualenvs/test/lib/python2.7/site-packages/IPython/terminal/embed.py", line 16, in <module>
        from IPython.core.interactiveshell import DummyMod
      File "/home/peque/.virtualenvs/test/lib/python2.7/site-packages/IPython/core/interactiveshell.py", line 31, in <module>
        from pickleshare import PickleShareDB
      File "/home/peque/.virtualenvs/test/lib/python2.7/site-packages/pickleshare.py", line 41, in <module>
        from path import path as Path
    ImportError: cannot import name path