### PR TITLE
Update setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ This module is certainly not ZODB, but can be used for low-load
 advanced features of a "real" object database.
 
 Installation guide: pip install path pickleshare
-"""
-
-
+""",
+    classifiers=[
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ]
 )


### PR DESCRIPTION
The readme says pickleshare supports Python 3.
The classifiers are used by PyPI to recognize Python 3 compatible packages (also by caniusepython3.com and developers).