### PR TITLE
Switch from path.py to pathlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.7"
   - "3.4"
   - 3.5
-install: pip install path.py
+install: pip install -e .
 script: py.test
 sudo: false

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setup(
     author_email="vivainio@gmail.com",
     description="Tiny 'shelve'-like database with concurrency support",
     license="MIT",
-    install_requires=["path.py>=6.2"],
+    extras_require = {
+        ':python_version == 2.7': ['pathlib2'],
+    },
     url="https://github.com/pickleshare/pickleshare",
     keywords="database persistence pickle ipc shelve",
     long_description="""\
@@ -48,6 +50,7 @@ Installation guide: pip install path pickleshare
 """,
     classifiers=[
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description="Tiny 'shelve'-like database with concurrency support",
     license="MIT",
     extras_require = {
-        ':python_version == 2.7': ['pathlib2'],
+        ':python_version == "2.7"': ['pathlib2'],
     },
     url="https://github.com/pickleshare/pickleshare",
     keywords="database persistence pickle ipc shelve",


### PR DESCRIPTION
path.py's use of setuptools has been causing issues for IPython users, see e.g. ipython/ipython#9383.

This switches to using pathlib, a similar object-oriented path API which is in the stdlib as of Python 3.4. For Python 2, we use the [pathlib2](https://pypi.python.org/pypi/pathlib2/) backport. Besides avoiding `pkg_resources`, more people are likely to be familiar with the pathlib API going forwards.

A trivial point is that it also reduces the likelihood of module clashes, because 'path' is a short, obvious name that people are more likely to use.