### PR TITLE
Fix for multiple processes creating a folder

### DIFF
--- a/pickleshare.py
+++ b/pickleshare.py
@@ -69,9 +69,9 @@ class PickleShareDB(collections.MutableMapping):
             # exists_ok keyword argument of mkdir does the same but only from Python 3.5
             try:
                 self.root.mkdir(parents=True)
-            # except FileExistsError: # this is Python > 3.3 only
-            except:
-                pass
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
         # cache has { 'key' : (obj, orig_mod_time) }
         self.cache = {}
 

--- a/pickleshare.py
+++ b/pickleshare.py
@@ -65,7 +65,13 @@ class PickleShareDB(collections.MutableMapping):
         root = os.path.abspath(os.path.expanduser(str(root)))
         self.root = Path(root)
         if not self.root.is_dir():
-            self.root.mkdir(parents=True)
+            # catching the exception is necessary if multiple processes are concurrently trying to create a folder
+            # exists_ok keyword argument of mkdir does the same but only from Python 3.5
+            try:
+                self.root.mkdir(parents=True)
+            # except FileExistsError: # this is Python > 3.3 only
+            except:
+                pass
         # cache has { 'key' : (obj, orig_mod_time) }
         self.cache = {}
 


### PR DESCRIPTION
it happens that with many processes accessing the same folder, some of them find that there is no folder and then simultaneously try to create one and this fails.

* Most elegant option would be to add `exists_ok=True` to `mkdir`, but it doesn't work on Python 3.4.
* Second would be to catch `FileExistsError`, but that is only for Python 3, not 2
* Catching the error on Python 2.7 is ugly so I'd rather just do a catch-all except...