### PR TITLE
Don't convert Py2 unicode path to str

### DIFF
--- a/pickleshare.py
+++ b/pickleshare.py
@@ -51,6 +51,12 @@ try:
 except ImportError:
     import pickle
 import errno
+import sys
+
+if sys.version_info[0] >= 3:
+    string_types = (str,)
+else:
+    string_types = (str, unicode)
 
 def gethashfile(key):
     return ("%02x" % abs(hash(key) % 256))[-2:]
@@ -61,7 +67,7 @@ class PickleShareDB(collections.MutableMapping):
     """ The main 'connection' object for PickleShare database """
     def __init__(self,root):
         """ Return a db object that will manage the specied directory"""
-        if isinstance(root, Path):
+        if not isinstance(root, string_types):
             root = str(root)
         root = os.path.abspath(os.path.expanduser(root))
         self.root = Path(root)

--- a/pickleshare.py
+++ b/pickleshare.py
@@ -61,7 +61,9 @@ class PickleShareDB(collections.MutableMapping):
     """ The main 'connection' object for PickleShare database """
     def __init__(self,root):
         """ Return a db object that will manage the specied directory"""
-        root = os.path.abspath(os.path.expanduser(str(root)))
+        if isinstance(root, Path):
+            root = str(root)
+        root = os.path.abspath(os.path.expanduser(root))
         self.root = Path(root)
         if not self.root.is_dir():
             # catching the exception is necessary if multiple processes are concurrently trying to create a folder

--- a/test_pickleshare.py
+++ b/test_pickleshare.py
@@ -4,7 +4,7 @@ import os
 from pickleshare import PickleShareDB
 
 def test_pickleshare(tmpdir):
-    db = PickleShareDB(str(tmpdir))
+    db = PickleShareDB(tmpdir)
     db.clear()
     print("Should be empty:",db.items())
     assert len(db) == 0
@@ -33,7 +33,7 @@ def test_pickleshare(tmpdir):
     assert lnk.bar == 7
 
 def test_stress(tmpdir):
-    db = PickleShareDB(str(tmpdir))
+    db = PickleShareDB(tmpdir)
     import time,sys
     for i in range(100):
         for j in range(500):

--- a/test_pickleshare.py
+++ b/test_pickleshare.py
@@ -4,7 +4,7 @@ import os
 from pickleshare import PickleShareDB
 
 def test_pickleshare(tmpdir):
-    db = PickleShareDB(tmpdir)
+    db = PickleShareDB(str(tmpdir))
     db.clear()
     print("Should be empty:",db.items())
     assert len(db) == 0
@@ -33,7 +33,7 @@ def test_pickleshare(tmpdir):
     assert lnk.bar == 7
 
 def test_stress(tmpdir):
-    db = PickleShareDB(tmpdir)
+    db = PickleShareDB(str(tmpdir))
     import time,sys
     for i in range(100):
         for j in range(500):


### PR DESCRIPTION
See ipython/ipython#9777

We still allow a pathlib Path object to be passed in.