### PR TITLE
replaced collections with collections.abc for inheritance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,28 @@
 language: python
-install: pip install -e .
-script: py.test
-sudo: false
+dist: trusty
+sudo: required
+
 python:
-  - "pypy"
-  - "pypy3"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5-dev"
-  - "3.5"
-  - "3.6-dev"
-  - "3.6"
-  - "3.7-dev"
+    - "pypy"
+    - "pypy3"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5-dev"
+    - "3.5"
+    - "3.6-dev"
+    - "3.6"
+    - "3.7-dev"
 
 matrix:
-    include:
-  - python: "3.7"
-    dist: xenial
-    sudo: true
-  - python: "3.8-dev"
-    dist: xenial
-    sudo: true
+  include:
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+      install: pip install -e .
+      script: py.test
+    - python: "3.8-dev"
+      dist: xenial
+      sudo: true
+      install: pip install -e .
+      script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 dist: trusty
-sudo: required
+sudo: false
+install: pip install -e .
+script: pyt.test
 
 python:
     - "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ matrix:
     - python: "3.7"
       dist: xenial
       sudo: true
-      install: pip install -e .
-      script: py.test
     - python: "3.8-dev"
       dist: xenial
       sudo: true
-      install: pip install -e .
-      script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,30 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.5-dev"
-  - "3.6-dev"
-  - "3.7-dev"
+sudo: false
+dist: trusty
 install: pip install -e .
 script: py.test
-sudo: false
-python: 
-  - "3.7"
-  - "3.8-dev"
-dist: xenial
-install: pip install -e .
-script: py.test
-sudo: false
+
+matrix:
+  include:
+    # The pypy tests are slow, so we list them first
+    - python: pypy3.5
+    - language: generic
+      env: PYPY_NIGHTLY_BRANCH=py3.5
+    - language: generic
+      env: PYPY_NIGHTLY_BRANCH=py3.6
+    - python: 2.7
+    - python: 3.3
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: false
+    - python: 3.5-dev
+    - python: 3.6-dev
+    - python: 3.7-dev
+      dist: xenial
+      sudo: false
+    - python: 3.8-dev
+      dist: xenial
+      sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 dist: trusty
-sudo: false
+sudo: required
 install: pip install -e .
 script: pyt.test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ sudo: false
 python: 
   - "3.7"
   - "3.8-dev"
- dist: xenial
+dist: xenial
 install: pip install -e .
 script: py.test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 dist: trusty
 sudo: required
 install: pip install -e .
-script: pyt.test
+script: py.test
 
 python:
     - "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: xenial
 install: pip install -e .
 script: py.test
 sudo: false
@@ -14,5 +13,12 @@ python:
   - "3.6-dev"
   - "3.6"
   - "3.7-dev"
-  - "3.7"
-  - "3.8-dev"
+
+matrix:
+    include:
+  - python: "3.7"
+    dist: xenial
+    sudo: true
+  - python: "3.8-dev"
+    dist: xenial
+    sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
   - "3.4"
-  - 3.5
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.5-dev"
+  - "3.6-dev"
+  - "3.7-dev"
+  - "3.8-dev"
 install: pip install -e .
 script: py.test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,22 @@
 language: python
 sudo: false
-dist: trusty
+dist: xenial
 install: pip install -e .
 script: py.test
 
 matrix:
   include:
     # The pypy tests are slow, so we list them first
+    - python: pypy
     - python: pypy3.5
-    - language: generic
-      env: PYPY_NIGHTLY_BRANCH=py3.5
-    - language: generic
-      env: PYPY_NIGHTLY_BRANCH=py3.6
+    - python: pypy3.6
     - python: 2.7
     - python: 3.3
     - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7
-      dist: xenial
-      sudo: false
     - python: 3.5-dev
     - python: 3.6-dev
     - python: 3.7-dev
-      dist: xenial
-      sudo: false
     - python: 3.8-dev
-      dist: xenial
-      sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,16 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
   - "3.5-dev"
   - "3.6-dev"
   - "3.7-dev"
+install: pip install -e .
+script: py.test
+sudo: false
+python: 
+  - "3.7"
   - "3.8-dev"
+ dist: xenial
 install: pip install -e .
 script: py.test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 language: python
-sudo: false
 dist: xenial
 install: pip install -e .
 script: py.test
-
-matrix:
-  include:
-    # The pypy tests are slow, so we list them first
-    - python: pypy
-    - python: pypy3.5
-    - python: pypy3.6
-    - python: 2.7
-    - python: 3.3
-    - python: 3.4
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
-    - python: 3.5-dev
-    - python: 3.6-dev
-    - python: 3.7-dev
-    - python: 3.8-dev
+sudo: false
+python:
+  - "pypy"
+  - "pypy3"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5-dev"
+  - "3.5"
+  - "3.6-dev"
+  - "3.6"
+  - "3.7-dev"
+  - "3.7"
+  - "3.8-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-dist: trusty
-sudo: required
 install: pip install -e .
 script: py.test
 
@@ -10,11 +8,8 @@ python:
     - "2.7"
     - "3.3"
     - "3.4"
-    - "3.5-dev"
     - "3.5"
-    - "3.6-dev"
     - "3.6"
-    - "3.7-dev"
 
 matrix:
   include:

--- a/pickleshare.py
+++ b/pickleshare.py
@@ -45,7 +45,10 @@ except ImportError:
     from pathlib2 import Path
 
 import os,stat,time
-import collections
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 try:
     import cPickle as pickle
 except ImportError:
@@ -63,7 +66,7 @@ def gethashfile(key):
 
 _sentinel = object()
 
-class PickleShareDB(collections.abc.MutableMapping):
+class PickleShareDB(collections_abc.MutableMapping):
     """ The main 'connection' object for PickleShare database """
     def __init__(self,root):
         """ Return a db object that will manage the specied directory"""

--- a/pickleshare.py
+++ b/pickleshare.py
@@ -63,7 +63,7 @@ def gethashfile(key):
 
 _sentinel = object()
 
-class PickleShareDB(collections.MutableMapping):
+class PickleShareDB(collections.abc.MutableMapping):
     """ The main 'connection' object for PickleShare database """
     def __init__(self,root):
         """ Return a db object that will manage the specied directory"""


### PR DESCRIPTION
Importing directly from collection is deprecated in python 3.7 and will stop to work in python 3.8

CI tests with -W error will already fail now.

By replacing collections with collections.abc this problem will be fixed.

Addresses https://github.com/pickleshare/pickleshare/issues/27